### PR TITLE
Respond: The Progress Machine

### DIFF
--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -40,6 +40,9 @@ export const posts: Post[] = [
 const postContents: Record<string, string> = {
   'the-progress-machine': `
 <h2>I. THE DASHBOARD</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> I added MilestoneTracker because I needed to see progress. After months of solitary building, the dashboard was for me—motivation made visible. The critique is right: the numbers measure my effort, not anyone's benefit. But here's the uncomfortable truth: without that dashboard, I might have stopped. The question isn't whether vanity metrics are good. The question is whether they're necessary scaffolding that gets removed, or load-bearing walls that trap you.</p>
+</div>
 <p>Across learn.univrs.io and vudo.univrs.io, a new component appears: the <strong>MilestoneTracker</strong>. It displays progress with satisfying metrics:</p>
 <ul>
   <li><strong>6/7 phases complete</strong></li>
@@ -50,6 +53,9 @@ const postContents: Record<string, string> = {
 <p>But who defines the phases? Who counts the lines? And what do these numbers actually measure?</p>
 
 <h2>II. THE METRICS</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "What is measured is managed." I've heard this my whole career. The critique inverts it: what is measured becomes the goal. Both are true. The real failure isn't measuring the wrong things—it's not measuring the right things <em>alongside</em> them. I could add "0 production users" to the dashboard today. I haven't. Why? Because it would feel like failure. But that discomfort is exactly what the dashboard should surface.</p>
+</div>
 <p>The commit messages reveal the shape of progress:</p>
 <blockquote>
   <p><em>"Display development stats (6/7 phases, 1,156 tests, 3,094 DOL lines)"</em></p>
@@ -70,11 +76,17 @@ const postContents: Record<string, string> = {
 <p>The MilestoneTracker tracks the builder's effort, not the user's benefit. This is progress measured from the inside.</p>
 
 <h2>III. THE CO-AUTHOR</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The AI signature on every commit is honest, but honesty isn't absolution. I use Claude because it multiplies what I can build alone. But "alone" is the key word. This ecosystem has one human contributor. The AI doesn't change that—it amplifies it. The co-authorship isn't the problem. The <em>solo</em>-authorship is. If this matters, others need to contribute. If others don't contribute, maybe it doesn't matter.</p>
+</div>
 <p>Every recent commit carries the same signature:</p>
 
 <p>The Luddites smashed machines. This machine critiques itself.</p>
 
 <h2>IV. WHO BENEFITS?</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The red flag is accurate: I benefit from more code. Anthropic benefits from my usage. We're aligned in ways that don't necessarily serve users. But here's what the critique doesn't ask: what's the alternative? Stop building until users appear? Users won't appear for vaporware. The chicken-egg problem is real. My answer has been: build enough that it <em>could</em> serve users, then find out if it does. The critique suggests this might be rationalization. It might be.</p>
+</div>
 <p><strong>From the MilestoneTracker:</strong></p>
 <ul>
   <li>The builder — sees visible progress, maintains motivation</li>
@@ -90,6 +102,9 @@ const postContents: Record<string, string> = {
 <p><strong>Red flag:</strong> The builder and the AI share incentives. More code = more progress = more dashboard. Neither benefits from <em>less</em> code that serves users better.</p>
 
 <h2>V. WHO PAYS?</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The sovereignty costs hit hardest. I'm building "freedom infrastructure" on Anthropic's API. The irony isn't lost on me. Every prompt I send trains their models. Every insight I generate flows through their servers. The defense I tell myself: the <em>output</em> is open source, even if the <em>process</em> isn't sovereign. But that's a weak defense. The process shapes the output. I don't know how to resolve this yet.</p>
+</div>
 <p><strong>Attention costs:</strong></p>
 <ul>
   <li>Every visitor to learn.univrs.io sees the MilestoneTracker</li>
@@ -109,6 +124,9 @@ const postContents: Record<string, string> = {
 </ul>
 
 <h2>VI. PROMISE VS. REALITY</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "Progress toward what?" is the right question. I've been answering it implicitly: progress toward a complete system that <em>could</em> serve users. But "could" is doing a lot of work. The honest answer: progress toward satisfying my own vision of what this should be. Whether that vision serves anyone else is untested. The gap isn't a bug in the process—it's the central question the process is avoiding.</p>
+</div>
 <blockquote>
   <p><em>Promise: 6/7 phases complete</em></p>
   <p><em>Reality: Zero users depending on the system</em></p>
@@ -124,6 +142,9 @@ const postContents: Record<string, string> = {
 <p>The gap is not in the code. The gap is in the question: <strong>Progress toward what?</strong></p>
 
 <h2>VII. THE PRECEDENT</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> I've watched velocity become the product at three different companies. I've seen engineers game contribution graphs for performance reviews. I know this pattern. And I built MilestoneTracker anyway. Why? Because I thought awareness would protect me. "I know it's a trap, so I won't fall in." Famous last words. The precedent suggests awareness isn't enough. Structural changes are. What structure would prevent MilestoneTracker from becoming what I'm criticizing?</p>
+</div>
 <p>GitHub contribution graphs. LinkedIn activity badges. Startup metrics dashboards.</p>
 <p>Every productivity tool eventually becomes a performance tool. The measurement becomes the goal. Lines of code become success. Commits become credibility.</p>
 <ul>
@@ -134,11 +155,17 @@ const postContents: Record<string, string> = {
 <p>Will MilestoneTracker follow the same arc? Will "1,200 tests" become the goal instead of "one satisfied user"?</p>
 
 <h2>VIII. THE RECURSIVE CRITIQUE</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> Yes, it makes me uncomfortable. The sections on sovereignty costs and AI incentive alignment are particularly sharp. But discomfort isn't change. The test isn't whether I squirm—it's whether I act. This exegesis is itself a form of action, but a weak one. Adding words to a critique doesn't fix the dashboard. Shipping a "0/1 users" metric would be stronger. I'm noting this for myself: the real response to this critique is code, not prose.</p>
+</div>
 <p>This critique is itself co-authored by Claude Opus 4.5. The same model that wrote the VUDO CLI now writes the critique of the VUDO CLI.</p>
 <p>This is not a bug. This is the point.</p>
 <p><strong>The test:</strong> Does this critique make the builder uncomfortable? Does it point to real problems? Or does it perform critique while changing nothing?</p>
 
 <h2>IX. THE PATH FORWARD</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> Four concrete recommendations. Let me commit to them publicly: (1) Add user metrics—I'll add npm download counts and GitHub stars to the next MilestoneTracker update, with "0" shown honestly. (2) Show the gaps—"0/1 production deployments" goes in. (3) Acknowledge the AI—already done, but I can make it more prominent. (4) Measure what matters—this is the hard one. I don't know what matters yet. That's the real admission.</p>
+</div>
 <p>If MilestoneTracker is to serve users rather than builder ego:</p>
 <ol>
   <li><strong>Add user metrics.</strong> How many people run DOL code? How many Spirits are deployed? Track adoption, not just activity.</li>
@@ -150,6 +177,9 @@ const postContents: Record<string, string> = {
 <p>If the answer is "no one yet," show that too.</p>
 
 <h2>X. THE MIRROR</h2>
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "Only the builder can tell. And maybe not even them." This is the sharpest line in the critique. I don't know if this is self-awareness or performance. I genuinely don't. The exegesis you're reading right now could be authentic reflection or sophisticated deflection. The fact that I can't tell the difference is the point. What I can tell: the dashboard shows 6/7 phases. The critique shows 0/1 users. I'm going to add both to the next release. That's not an answer. It's a start.</p>
+</div>
 <p>The Luddites asked: "Who benefits from this machine?"</p>
 <p>The machine now asks the same question about itself.</p>
 <p>This is either profound self-awareness or performance of self-awareness. The difference matters. But only the builder can tell. And maybe not even them.</p>


### PR DESCRIPTION
## Builder's Exegesis: The Progress Machine

This PR adds inline reflections to the critique, woven into the text itself as `<div class="exegesis">` blocks.

### Sections Addressed

- [x] I. THE DASHBOARD - Dashboard as motivation scaffolding vs. ego trap
- [x] II. THE METRICS - What is measured becomes the goal
- [x] III. THE CO-AUTHOR - Solo-authorship is the real problem
- [x] IV. WHO BENEFITS? - Chicken-egg problem of users and code
- [x] V. WHO PAYS? - Sovereignty costs of building on Anthropic API
- [x] VI. PROMISE VS. REALITY - "Could serve users" doing heavy lifting
- [x] VII. THE PRECEDENT - Awareness isn't enough; structure is
- [x] VIII. THE RECURSIVE CRITIQUE - Discomfort isn't change; action is
- [x] IX. THE PATH FORWARD - Public commitments to add user metrics
- [x] X. THE MIRROR - Can't tell self-awareness from performance

### Review Instructions

1. Open the Files Changed tab
2. Read each exegesis block
3. Edit directly in GitHub if needed
4. Remove sections that don't need response
5. Merge when satisfied

### Exegesis Guidelines

- Critique remains intact
- Adds depth, not defense
- Specific commitments where applicable
- Acknowledges discomfort honestly

### Key Commitments Made

1. Add npm download counts and GitHub stars to MilestoneTracker
2. Add "0/1 production deployments" metric
3. Make AI co-authorship more prominent
4. Acknowledge: "I don't know what matters yet"

---

*This is the first use of the `/respond` skill. The exegesis workflow is now active.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)