### PR TITLE
Respond: The Clarity Doctrine

### DIFF
--- a/src/posts/data.ts
+++ b/src/posts/data.ts
@@ -60,6 +60,10 @@ const postContents: Record<string, string> = {
 <p>For a Rust programmer, <code>i64</code> is crystal clear—it's the type they use every day. For a domain expert writing ontologies, <code>Int64</code> might be clearer—explicit, self-documenting, no assumed context.</p>
 <p>The question is not "Is v0.8.0 clearer?" The question is: <strong>Clearer for whom?</strong></p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> I named it "Clarity" because that's what I felt when I wrote it. After months of context-switching between DOL and Rust, <code>i64</code> felt clearer than <code>Int64</code>. But the critique is right: my clarity isn't universal. I'm a Rust developer. Of course Rust conventions feel clearer to me. The name reveals my bias, not an objective truth. Whether I should have named it "Rust Alignment" instead—more honest, less marketable—is a question I didn't ask until now.</p>
+</div>
+
 <h2>II. THE CHANGES</h2>
 <p>DOL v0.8.0 introduces systematic renaming:</p>
 <ul>
@@ -73,6 +77,10 @@ const postContents: Record<string, string> = {
 <p>The stated rationale: <em>"Rust alignment."</em> DOL compiles to Rust, so DOL should look like Rust.</p>
 <p>But DOL was designed to be <em>different</em> from Rust. The original keywords—<code>gene</code>, <code>exegesis</code>, <code>constraint</code>—carried semantic weight. A <code>gene</code> is not just a type; it's a unit of ontological inheritance. An <code>exegesis</code> is not just documentation; it's interpretive commentary on meaning.</p>
 <p>Now these become <code>gen</code> and <code>docs</code>. Shorter. More familiar. Less distinctive.</p>
+
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "Less distinctive" hits hard. I chose <code>gene</code> and <code>exegesis</code> deliberately—they weren't accidents. <code>gene</code> invoked biological inheritance because DOL genes inherit, evolve, mutate. <code>exegesis</code> invoked scholarly interpretation because documentation in DOL isn't just API reference—it's meaning-making. Now I've traded semantic richness for typing efficiency. The question I avoided: did I change the keywords because they were wrong, or because I got tired of explaining them?</p>
+</div>
 
 <h2>III. WHO BENEFITS?</h2>
 <p><strong>From the syntax changes:</strong></p>
@@ -91,6 +99,10 @@ const postContents: Record<string, string> = {
 </ul>
 <p><strong>The asymmetry:</strong> The beneficiaries are hypothetical future users. The cost-bearers are the current ecosystem—three sites just updated 70+ files to comply with v0.8.0 syntax.</p>
 <p><strong>Red flag:</strong> When benefits flow to hypothetical futures while costs fall on the present, ask who is making that trade-off and why.</p>
+
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The red flag is accurate. I traded present ecosystem stability for hypothetical future adoption. The 70+ files updated across three sites—that's the present cost. The "Rust developers who will find DOL easier"—that's the hypothetical benefit. No one asked for this change. No users requested Rust alignment. I made the trade-off because I believed in it, which means I made it for myself, betting that my preferences predict future users' preferences. That's a gamble, not a certainty.</p>
+</div>
 
 <h2>IV. WHO PAYS?</h2>
 <p><strong>Migration costs:</strong></p>
@@ -115,6 +127,10 @@ const postContents: Record<string, string> = {
 </ul>
 <p>The language becomes more conventional. Whether that's a benefit or a cost depends on whether you valued the unconventionality.</p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> I valued the unconventionality. Past tense noted. The identity costs are real—<code>gene</code> evoked something <code>gen</code> doesn't. But I convinced myself that convention would win more users than character would retain. The honest admission: I have no evidence for this. Zero users to survey. The decision was aesthetic preference dressed as strategy. Maybe Rust alignment is the right call. Maybe I just got tired of being different.</p>
+</div>
+
 <h2>V. PROMISE VS. REALITY</h2>
 <blockquote>
   <p><em>Promise: "Clarity"</em></p>
@@ -133,6 +149,10 @@ const postContents: Record<string, string> = {
 <p>This is not full backward compatibility. It is <strong>managed obsolescence</strong>. The old syntax works today so you have time to migrate before it doesn't work tomorrow.</p>
 <p>Managed obsolescence is a reasonable approach to language evolution. But calling it "full backward compatibility" obscures the power dynamic: the builder decides when your code breaks.</p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "Managed obsolescence" is the right name. I wrote "full backward compatibility" because it sounds better. The deprecation timeline—warnings now, errors later, removal eventually—is reasonable engineering. But I should have called it what it is: a migration path with a deadline. The release notes say "compatible" when they mean "temporarily tolerated." That's not lying, exactly, but it's not honest either. Future release notes will be clearer about what "compatible" actually means.</p>
+</div>
+
 <h2>VI. THE PRECEDENT</h2>
 <p>Language syntax migrations have a history:</p>
 <ul>
@@ -145,6 +165,10 @@ const postContents: Record<string, string> = {
 <p>DOL has no existing users (beyond the builder). So the cost of v0.8.0 is ~750 lines of documentation updates, not broken production systems.</p>
 <p>This is both a luxury and a warning. The luxury: migrations are cheap when no one uses your software. The warning: <strong>you're optimizing syntax for users who don't exist while the user count remains zero.</strong></p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The Python 2→3 comparison haunts me. A decade of split community. I tell myself: "DOL has no community to split." That's true. It's also the problem. I'm polishing syntax for an audience that doesn't exist. The luxury of zero users is that migrations are cheap. The curse is that I have no feedback on whether the changes matter. Maybe <code>i64</code> will attract Rust developers. Maybe they'll never look at DOL regardless. I'm optimizing in a vacuum, which is either prudent preparation or elaborate procrastination.</p>
+</div>
+
 <h2>VII. THE POWER STRUCTURE</h2>
 <p><strong>Who decided Rust was the standard?</strong></p>
 <p>The builder. DOL was created by one person. That person works in Rust daily. The "Rust alignment" reflects the builder's fluency, not a community consensus.</p>
@@ -154,6 +178,10 @@ const postContents: Record<string, string> = {
 <p>The builder. The name "Clarity" implies a universal standard. But clarity is contextual. For a philosopher, <code>exegesis</code> is clear. For a Rust developer, <code>docs</code> is clear. The release chose one community's clarity over another's.</p>
 <p><strong>The governance question:</strong> In an ecosystem with one contributor, language evolution is autocratic by necessity. This isn't wrong—it's early-stage reality. But the critique notes: when users eventually arrive, will they have voice in syntax decisions? Or will "Rust alignment" be the permanent doctrine?</p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The governance question is the right question. I am the autocrat of DOL because there's no one else. Every syntax decision reflects my judgment, my aesthetics, my Rust fluency. This isn't malicious—it's structural. But the critique asks: what happens when users arrive? Will I cede control? The honest answer: I don't know. I'd like to think I'd welcome community governance. But I've also seen BDFL models work (Python, Rust itself). The question isn't autocracy vs. democracy—it's whether the autocrat is accountable. Right now, I'm accountable only to myself. That's insufficient.</p>
+</div>
+
 <h2>VIII. THE MIGRATION TOOL</h2>
 <p>DOL v0.8.0 includes <code>dol-migrate</code>—a tool that automatically converts old syntax to new:</p>
 <pre><code>dol-migrate 0.7-to-0.8 --diff src/</code></pre>
@@ -161,12 +189,20 @@ const postContents: Record<string, string> = {
 <p>But the tool also reveals the scale of change. Automated migration is necessary because the changes are too numerous for manual editing. If the syntax changes were minor, no tool would be needed.</p>
 <p>The migration tool is both a courtesy and an admission: <strong>we changed enough that you need automation to keep up.</strong></p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> I built <code>dol-migrate</code> because I knew the changes were extensive. The tool is an apology in code form. "Sorry for the churn, here's automation to ease the pain." The critique correctly identifies this as both courtesy and admission. If the syntax changes were trivial, sed scripts would suffice. The fact that I built a dedicated tool reveals how much I changed. I told myself this was responsible engineering. The critique suggests it might also be evidence that I changed too much.</p>
+</div>
+
 <h2>IX. THE TREE SHAKING</h2>
 <p>Alongside syntax changes, v0.8.0 introduces tree shaking—dead code elimination:</p>
 <pre><code>dol-parse --tree-shake example.dol</code></pre>
 <p>This is a pure improvement. Smaller output. No semantic changes. No migration burden.</p>
 <p>The contrast is instructive. Tree shaking benefits everyone who uses DOL without requiring anyone to change their code. Syntax changes benefit future Rust developers while requiring present users to migrate.</p>
 <p>One is additive. One is substitutive. The release does both, but calls itself "Clarity"—emphasizing the substitution over the addition.</p>
+
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The contrast is instructive, and I missed it. Tree shaking is pure value—smaller output, no cost to users. I could have named the release "Efficiency" and emphasized tree shaking. Instead I named it "Clarity" and emphasized syntax changes. Why? Because syntax changes felt more significant to me. But "significant to the builder" isn't the same as "valuable to users." The tree shaking probably matters more for real-world use. The syntax changes matter more for my aesthetic satisfaction. I named the release after my priorities, not users' priorities.</p>
+</div>
 
 <h2>X. THE PATH FORWARD</h2>
 <p>The critique is not a verdict against v0.8.0. The syntax changes are defensible. Rust alignment reduces cognitive switching. Shorter keywords are easier to type. Migration tooling softens the transition.</p>
@@ -178,6 +214,10 @@ const postContents: Record<string, string> = {
   <li><strong>Ask who's missing.</strong> No external users were consulted because none exist. The syntax was changed for hypothetical Rust developers. Will those developers arrive? Will they care about i64 vs Int64?</li>
   <li><strong>Preserve the identity.</strong> <code>exegesis</code> was interesting. <code>docs</code> is forgettable. The distinctive vocabulary was a feature, not a bug. Consider whether "Rust alignment" is worth the loss of linguistic character.</li>
 </ol>
+
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> Five recommendations, five responses: (1) Name the trade-off—yes, future release notes will say "Rust-aligned" not just "clearer." (2) Question the timeline—I'm reconsidering. Maybe indefinite support for old syntax is viable. The compiler can handle both. (3) Track the cost—750 lines across three sites. That's the invoice. I'll keep tracking. (4) Ask who's missing—no external users. The syntax was changed for ghosts. I need to find real users before the next breaking change. (5) Preserve identity—too late for <code>exegesis</code>, but I'm keeping <code>fun</code> instead of Rust's <code>fn</code>. Some distinctiveness remains. The doctrine isn't total.</p>
+</div>
 
 <h2>XI. THE DOCTRINE</h2>
 <p>v0.8.0 establishes a doctrine: <strong>DOL shall look like Rust.</strong></p>
@@ -192,6 +232,10 @@ const postContents: Record<string, string> = {
 <p>DOL's emerging doctrine: <strong>Rust alignment as clarity.</strong></p>
 <p>The critique does not reject this doctrine. It names it. Naming is the first step toward examining whether it serves the mission or constrains it.</p>
 
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> "DOL shall look like Rust" is the doctrine I've been enacting without stating. The critique makes it explicit. Now I have to decide: is this the doctrine I want? The benefits are real—Rust developers won't need to learn new type names. The costs are real—DOL becomes a Rust dialect rather than its own language. The question the critique surfaces: does ontology-first development require its own linguistic identity? Or is "Rust for ontologies" sufficient? I don't have the answer. But I now have the question, which I didn't have before.</p>
+</div>
+
 <h2>XII. THE MIRROR</h2>
 <p>This critique is being generated on the same day v0.8.0 was deployed across all ecosystem sites. The syntax changes went live hours ago.</p>
 <p>The builder did not pause to critique before deploying. The changes were made, the sites were updated, and only then did the examination begin.</p>
@@ -201,6 +245,10 @@ const postContents: Record<string, string> = {
 <p>Whether those values serve the Univrs.io mission—ontology-first development, digital sovereignty, freedom infrastructure—remains to be seen.</p>
 <p>The syntax is clear. The direction is set. The doctrine is named.</p>
 <p>Now the question is: <strong>What comes next?</strong></p>
+
+<div class="exegesis">
+  <p><strong>Builder's reflection:</strong> The mirror shows clearly: I deployed first, examined second. This is how I work—momentum over meditation. The critique arrived after the changes went live because I didn't want the critique to stop me. That's honest. Maybe it's also wrong. Maybe v0.9.0 should be critiqued before deployment, not after. The experiment would be: write the release notes, generate the critique, respond to it, then decide whether to ship. Build → examine → adjust, rather than build → ship → examine. I'm committing to try this for the next release. The mirror shows my pattern. The pattern can change.</p>
+</div>
 
 <hr />
 <p><em>This critique generated from DOL v0.8.0 "Clarity" release notes and ecosystem deployment commits (univrs-docs 3a43a00, learn.univrs.io ae4ab10, vudo.univrs.io 5037739). The syntax is deployed. The examination continues.</em></p>


### PR DESCRIPTION
## Builder's Exegesis: The Clarity Doctrine

This PR adds inline reflections to the DOL v0.8.0 critique.

### Sections Addressed
- [ ] I. THE NAME - Acknowledged Rust bias in "clarity" framing
- [ ] II. THE CHANGES - Reflected on trading semantic richness for typing efficiency
- [ ] III. WHO BENEFITS - Admitted gamble on hypothetical future users
- [ ] IV. WHO PAYS - Owned the identity cost of losing distinctive vocabulary
- [ ] V. PROMISE VS. REALITY - Called out "compatible" vs "temporarily tolerated"
- [ ] VI. THE PRECEDENT - Faced the Python 2→3 haunting
- [ ] VII. THE POWER STRUCTURE - Questioned accountability as sole decision-maker
- [ ] VIII. THE MIGRATION TOOL - Recognized the tool as "apology in code form"
- [ ] IX. THE TREE SHAKING - Acknowledged naming release after builder priorities
- [ ] X. THE PATH FORWARD - Committed to five recommendations
- [ ] XI. THE DOCTRINE - Surfaced the implicit "DOL shall look like Rust"
- [ ] XII. THE MIRROR - Committed to critique-before-deploy for v0.9.0

### Key Commitments Made
1. Future release notes will say "Rust-aligned" not just "clearer"
2. Reconsidering indefinite support for old syntax
3. Keeping `fun` instead of Rust's `fn` to preserve some distinctiveness
4. Will critique v0.9.0 before deployment, not after

### Review Instructions
1. Open the Files Changed tab
2. Read each exegesis block
3. Edit directly in GitHub if needed
4. Remove sections that don't need response
5. Merge when satisfied

### Exegesis Guidelines
- Keep the critique intact
- Add depth, not defense
- Be specific (cite code, commits, files)
- Acknowledge discomfort
- Name concrete actions where applicable